### PR TITLE
Hotfix: Bumped netty version to 4.1.63.Final, to fix 2 medium vulnerabilites

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,7 @@ kotlin.code.style=official
 coroutinesVersion=1.5.0-RC
 serializationVersion=1.1.0
 configurateVersion=4.0.0
-nettyVersion=4.1.59.Final
-#nettyVersion=4.1.54.Fina
+nettyVersion=4.1.63.Final
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 pom.kommon.name=Kommon
 pom.kommon.description=Kommon is a collection of tools written in Kotlin


### PR DESCRIPTION
There were two cves in netty. <br />
https://sbom.lift.sonatype.com/report/T1-0ff0976f7f21c391f20f-1c9ade44216149-1620898918-dd8d6515c9824442a236679a9ab503e9